### PR TITLE
map[string]any対応

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,10 +12,11 @@ $ go install github.com/yuukiiwai/blindspot/cmd/cli/blindspot@latest
 ```
 
 ## 使用方法
-1. 状態遷移jsonを作成する
+1. 状態遷移ファイルを作成する（JSON形式でstringlist、またはYAML形式でcud）
 2. コマンドを実行する
     ```sh
-    $ blindspot -input data.json -output mermaid
+    $ blindspot data.json -input stringlist -output mermaid
+    $ blindspot data.yaml -input cud -output mermaid
     ```
 
 ### 制限モード
@@ -23,7 +24,7 @@ $ go install github.com/yuukiiwai/blindspot/cmd/cli/blindspot@latest
 
 無限ループを防ぐため、反復回数の上限を設定することを強く推奨します：
 ```sh
-$ blindspot -input data.json -output mermaid --limit 1000
+$ blindspot data.json -input stringlist -output mermaid --limit 1000
 ```
 
 ## 便利な使い方
@@ -32,7 +33,7 @@ data.jsonのルールを元に書かれた状態遷移図をoutput.svgに記載
 ### mermaidを末尾に置く
 target.mdの末尾にグラフを設置する
 ```sh
-$ echo '```mermaid'; blindspot -input data.json -output mermaid; echo '```' >> target.md
+$ echo '```mermaid'; blindspot data.json -input stringlist -output mermaid; echo '```' >> target.md
 ```
 
 ### graphvizを使用してsvgを生成する
@@ -40,7 +41,7 @@ $ echo '```mermaid'; blindspot -input data.json -output mermaid; echo '```' >> t
 > 前提: graphvizがインストールされていること
 
 ```sh
-$ blindspot -input data.json -output dot | dot -Tsvg -o output.svg
+$ blindspot data.json -input stringlist -output dot | dot -Tsvg -o output.svg
 ```
 
 ## コントリビューター向け
@@ -59,10 +60,11 @@ $ go install github.com/yuukiiwai/blindspot/cmd/cli/blindspot@latest
 ```
 
 ## Usage
-1. make state json
-2. execute under command
+1. Create state transition file (JSON format for stringlist, or YAML format for cud)
+2. Execute command
     ```sh
-    $ blindspot -input data.json -output mermaid
+    $ blindspot data.json -input stringlist -output mermaid
+    $ blindspot data.yaml -input cud -output mermaid
     ```
 
 ### Limit Mode
@@ -70,7 +72,7 @@ $ go install github.com/yuukiiwai/blindspot/cmd/cli/blindspot@latest
 
 It is strongly recommended to set an upper limit on iterations to prevent infinite loops:
 ```sh
-$ blindspot -input data.json -output mermaid --limit 1000
+$ blindspot data.json -input stringlist -output mermaid --limit 1000
 ```
 
 ## Convenient Usage
@@ -79,7 +81,7 @@ Generate state transition diagrams based on data.json rules and save to output.s
 ### Append mermaid to file
 Place graph at the end of target.md
 ```sh
-$ echo '```mermaid'; blindspot -input data.json -output mermaid; echo '```' >> target.md
+$ echo '```mermaid'; blindspot data.json -input stringlist -output mermaid; echo '```' >> target.md
 ```
 
 ### Generate SVG using graphviz
@@ -87,7 +89,7 @@ $ echo '```mermaid'; blindspot -input data.json -output mermaid; echo '```' >> t
 > Prerequisite: graphviz must be installed
 
 ```sh
-$ blindspot -input data.json -output dot | dot -Tsvg -o output.svg
+$ blindspot data.json -input stringlist -output dot | dot -Tsvg -o output.svg
 ```
 
 ## For Contributers

--- a/cmd/cli/blindspot/helper.go
+++ b/cmd/cli/blindspot/helper.go
@@ -2,29 +2,30 @@ package main
 
 import (
 	"fmt"
-	"path"
 	"strings"
 
 	"github.com/yuukiiwai/blindspot/pkg/core"
+	"github.com/yuukiiwai/blindspot/pkg/std-impl/cud"
 	"github.com/yuukiiwai/blindspot/pkg/std-impl/stringlist"
 )
 
 var parserMap = map[string](func() (core.Parser, error)){
-	".json": stringlist.NewRuledJsonParser,
+	"stringlist": stringlist.NewRuledJsonParser,
+	"cud":        cud.NewCudYamlParser,
 }
 
-func getSupportedExtensions() []string {
-	extensions := make([]string, 0, len(parserMap))
-	for ext := range parserMap {
-		extensions = append(extensions, ext)
+func getSupportedFormats() []string {
+	formats := make([]string, 0, len(parserMap))
+	for format := range parserMap {
+		formats = append(formats, format)
 	}
-	return extensions
+	return formats
 }
 
-func getParser(inputFile string) (core.Parser, error) {
-	parser, ok := parserMap[path.Ext(inputFile)]
+func getParser(inputFormat string) (core.Parser, error) {
+	parser, ok := parserMap[inputFormat]
 	if !ok {
-		return nil, fmt.Errorf("unsupported file extension: %s\nWe can only parse %v files", path.Ext(inputFile), strings.Join(getSupportedExtensions(), ", "))
+		return nil, fmt.Errorf("unsupported input format: %s\nWe can only parse %v formats", inputFormat, strings.Join(getSupportedFormats(), ", "))
 	}
 	return parser()
 }
@@ -32,21 +33,22 @@ func getParser(inputFile string) (core.Parser, error) {
 func getCommandDefinition() string {
 	return `
 	Usage:
-		blindspot -input <input_file> [OPTIONS]
+		blindspot <input_file> [OPTIONS]
 		blindspot -help
 
 	Required:
-		-input string (入力ファイルのパス)
+		<input_file> string (入力ファイルのパス)
 
 	Options:
+		-input string (stringlist, cud) default: stringlist
 		-output string (mermaid, visjs, dot) default: mermaid
 		-log-severity string (debug, info, warn, error) default: warn
 		--limit int64 (反復回数の上限、無限ループ防止) default: 0 (無制限)
 
 	Examples:
-		blindspot -input rules.json -output mermaid
-		blindspot -input rules.json -output visjs
-		blindspot -input rules.json -output dot -log-severity debug
-		blindspot -input rules.json -output mermaid --limit 1000
+		blindspot rules.json -input stringlist -output mermaid
+		blindspot rules.json -input cud -output visjs
+		blindspot rules.json -input stringlist -output dot -log-severity debug
+		blindspot rules.json -input stringlist -output mermaid --limit 1000
 	`
 }

--- a/example/cud.yaml
+++ b/example/cud.yaml
@@ -1,0 +1,39 @@
+start_resources: {}
+
+edge_rules:
+  - name: create_a
+    effect: 
+      - action: create
+        resource:
+          key: a
+          value: {}
+    fire_condition: ""
+    block_condition: ""
+
+  - name: create_b_from_a
+    effect:
+      - action: create
+        resource:
+          key: b
+          value: {}
+    fire_condition: a != nil
+    block_condition: b != nil
+
+  - name: delete_b
+    effect:
+      - action: delete
+        resource:
+          key: b
+          value: ""
+    fire_condition: b != nil
+    block_condition: ""
+
+  - name: delete_a
+    effect:
+      - action: delete
+        resource:
+          key: a
+          value: ""
+    fire_condition: a != nil
+    block_condition: b != nil
+    

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,8 @@
 module github.com/yuukiiwai/blindspot
 
 go 1.24.3
+
+require (
+	github.com/expr-lang/expr v1.17.5
+	gopkg.in/yaml.v3 v3.0.1
+)

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,6 @@
+github.com/expr-lang/expr v1.17.5 h1:i1WrMvcdLF249nSNlpQZN1S6NXuW9WaOfF5tPi3aw3k=
+github.com/expr-lang/expr v1.17.5/go.mod h1:8/vRC7+7HBzESEqt5kKpYXxrxkr31SaO8r40VO/1IT4=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/pkg/core/generator.go
+++ b/pkg/core/generator.go
@@ -116,6 +116,15 @@ func (g *Generator) GetEdges() []*Edge {
 	return g.edges
 }
 
+// GetStartNode 開始ノードを取得
+func (g *Generator) GetStartNode() *Node {
+	startNode := g.newNode(g.startResources.GetResources())
+	if node, exists := g.nodes[startNode.GetID()]; exists {
+		return &node
+	}
+	return nil
+}
+
 // addOrGetNode ノードを追加または取得
 func (g *Generator) addOrGetNode(node *Node) *Node {
 	id := (*node).GetID()

--- a/pkg/std-impl/cud/cud_test.go
+++ b/pkg/std-impl/cud/cud_test.go
@@ -118,8 +118,8 @@ edge_rules:
 func TestCudNodeOperations(t *testing.T) {
 	// 空ノードのテスト
 	emptyNode := newCudNode(nil)
-	if emptyNode.GetID() != "empty" {
-		t.Errorf("Expected empty node ID to be 'empty', got %s", emptyNode.GetID())
+	if emptyNode.GetID() != "d41d8cd98f00b204e9800998ecf8427e" {
+		t.Errorf("Expected empty node ID to be 'd41d8cd98f00b204e9800998ecf8427e', got %s", emptyNode.GetID())
 	}
 
 	// 通常ノードのテスト

--- a/pkg/std-impl/cud/cud_test.go
+++ b/pkg/std-impl/cud/cud_test.go
@@ -1,0 +1,165 @@
+package cud
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestCudYamlParser(t *testing.T) {
+	yamlInput := `
+start_resources:
+  user_count: 0
+  server_status: "stopped"
+
+edge_rules:
+  - name: start_server
+    effect:
+      - action: update
+        resource:
+          key: server_status
+          value: "running"
+    fire_condition: server_status == "stopped"
+    block_condition: user_count > 100
+
+  - name: add_user
+    effect:
+      - action: update
+        resource:
+          key: user_count
+          value: user_count + 1
+    fire_condition: server_status == "running"
+    block_condition: user_count >= 50
+
+  - name: create_log
+    effect:
+      - action: create
+        resource:
+          key: log_entry
+          value: "server started"
+    fire_condition: server_status == "running" && !has("log_entry")
+    block_condition: ""
+
+  - name: stop_server
+    effect:
+      - action: update
+        resource:
+          key: server_status
+          value: "stopped"
+      - action: delete
+        resource:
+          key: log_entry
+          value: ""
+    fire_condition: server_status == "running" && user_count == 0
+    block_condition: ""
+`
+
+	parser, err := NewCudYamlParser()
+	if err != nil {
+		t.Fatalf("Failed to create parser: %v", err)
+	}
+
+	firstResource, newNode, edgeRules, err := parser.Parse(yamlInput)
+	if err != nil {
+		t.Fatalf("Failed to parse YAML: %v", err)
+	}
+
+	// 初期リソースの確認
+	if firstResource == nil {
+		t.Fatal("First resource is nil")
+	}
+
+	resources := firstResource.GetResources().(map[string]any)
+	if resources["user_count"] != 0 {
+		t.Errorf("Expected user_count to be 0, got %v", resources["user_count"])
+	}
+	if resources["server_status"] != "stopped" {
+		t.Errorf("Expected server_status to be 'stopped', got %v", resources["server_status"])
+	}
+
+	// エッジルールの数を確認
+	if len(edgeRules) != 4 {
+		t.Errorf("Expected 4 edge rules, got %d", len(edgeRules))
+	}
+
+	// エッジルール名の確認
+	expectedNames := []string{"start_server", "add_user", "create_log", "stop_server"}
+	for i, rule := range edgeRules {
+		if rule.Name != expectedNames[i] {
+			t.Errorf("Expected rule name %s, got %s", expectedNames[i], rule.Name)
+		}
+	}
+
+	// newNode関数のテスト
+	testResources := map[string]any{"test": "value"}
+	testNode := newNode(testResources)
+	if testNode == nil {
+		t.Fatal("newNode returned nil")
+	}
+
+	// ID生成のテスト
+	id := firstResource.GetID()
+	if id == "" {
+		t.Error("GetID returned empty string")
+	}
+
+	// ResourcesStringのテスト
+	resourceStrings := firstResource.GetResourcesString()
+	if len(resourceStrings) == 0 {
+		t.Error("GetResourcesString returned empty slice")
+	}
+
+	// 複数要素を含む文字列表現の確認
+	resourceString := strings.Join(resourceStrings, " ")
+	if !strings.Contains(resourceString, "user_count") || !strings.Contains(resourceString, "server_status") {
+		t.Errorf("Resource string doesn't contain expected keys: %s", resourceString)
+	}
+}
+
+func TestCudNodeOperations(t *testing.T) {
+	// 空ノードのテスト
+	emptyNode := newCudNode(nil)
+	if emptyNode.GetID() != "empty" {
+		t.Errorf("Expected empty node ID to be 'empty', got %s", emptyNode.GetID())
+	}
+
+	// 通常ノードのテスト
+	resources := map[string]any{
+		"key1": "value1",
+		"key2": 42,
+		"key3": true,
+	}
+	node := newCudNode(resources)
+
+	// ID生成の一意性テスト
+	id1 := node.GetID()
+	id2 := node.GetID()
+	if id1 != id2 {
+		t.Error("GetID should return consistent results")
+	}
+
+	// 異なるリソースの異なるIDテスト
+	resources2 := map[string]any{
+		"key1": "different_value",
+		"key2": 42,
+		"key3": true,
+	}
+	node2 := newCudNode(resources2)
+	if node.GetID() == node2.GetID() {
+		t.Error("Different resources should have different IDs")
+	}
+
+	// Equalsテスト
+	node3 := newCudNode(resources)
+	if !node.Equals(node3) {
+		t.Error("Nodes with same resources should be equal")
+	}
+	if node.Equals(node2) {
+		t.Error("Nodes with different resources should not be equal")
+	}
+
+	// GetResourcesStringテスト
+	resourceStrings := node.GetResourcesString()
+	if len(resourceStrings) != 3 {
+		t.Errorf("Expected 3 resource strings, got %d", len(resourceStrings))
+	}
+}

--- a/pkg/std-impl/cud/input.go
+++ b/pkg/std-impl/cud/input.go
@@ -1,0 +1,182 @@
+package cud
+
+import (
+	"fmt"
+
+	"github.com/expr-lang/expr"
+	"github.com/yuukiiwai/blindspot/pkg/core"
+	"gopkg.in/yaml.v3"
+)
+
+type CudYaml struct {
+	StartResources map[string]any `yaml:"start_resources"`
+	EdgeRules      []struct {
+		Name   string `yaml:"name"`
+		Effect []struct {
+			Action   string `yaml:"action"` // create, update, delete
+			Resource struct {
+				Key   string `yaml:"key"`
+				Value any    `yaml:"value"`
+			} `yaml:"resource"`
+		} `yaml:"effect"`
+		FireCondition  string `yaml:"fire_condition"`  // expr-lang expression
+		BlockCondition string `yaml:"block_condition"` // expr-lang expression
+	} `yaml:"edge_rules"`
+}
+
+func createFireConditionFunc(conditionExpr string) func(*core.Node) bool {
+	if conditionExpr == "" {
+		return func(n *core.Node) bool {
+			resources, ok := (*n).GetResources().(map[string]any)
+			if !ok {
+				panic(fmt.Sprintf("node resources is not map[string]any: %v", n))
+			}
+			return len(resources) == 0
+		}
+	}
+
+	program, err := expr.Compile(conditionExpr)
+	if err != nil {
+		panic(fmt.Sprintf("failed to compile fire condition expression: %s, error: %v", conditionExpr, err))
+	}
+
+	return func(n *core.Node) bool {
+		resources, ok := (*n).GetResources().(map[string]any)
+		if !ok {
+			panic(fmt.Sprintf("node resources is not map[string]any: %v", n))
+		}
+
+		result, err := expr.Run(program, resources)
+		if err != nil {
+			panic(fmt.Sprintf("failed to evaluate fire condition: %s, error: %v", conditionExpr, err))
+		}
+
+		boolResult, ok := result.(bool)
+		if !ok {
+			panic(fmt.Sprintf("fire condition expression must return bool, got: %T", result))
+		}
+
+		return boolResult
+	}
+}
+
+func createBlockConditionFunc(conditionExpr string) func(*core.Node) bool {
+	if conditionExpr == "" {
+		return func(n *core.Node) bool {
+			return false
+		}
+	}
+
+	program, err := expr.Compile(conditionExpr)
+	if err != nil {
+		panic(fmt.Sprintf("failed to compile block condition expression: %s, error: %v", conditionExpr, err))
+	}
+
+	return func(n *core.Node) bool {
+		resources, ok := (*n).GetResources().(map[string]any)
+		if !ok {
+			panic(fmt.Sprintf("node resources is not map[string]any: %v", n))
+		}
+
+		result, err := expr.Run(program, resources)
+		if err != nil {
+			panic(fmt.Sprintf("failed to evaluate block condition: %s, error: %v", conditionExpr, err))
+		}
+
+		boolResult, ok := result.(bool)
+		if !ok {
+			panic(fmt.Sprintf("block condition expression must return bool, got: %T", result))
+		}
+
+		return boolResult
+	}
+}
+
+func NewCudYamlParser() (core.Parser, error) {
+	return &CudYaml{}, nil
+}
+
+func (c *CudYaml) Parse(input string) (
+	firstResource core.Node,
+	newNode func(any) core.Node,
+	edgeRules []*core.EdgeRule,
+	err error,
+) {
+	var cudYaml CudYaml
+	err = yaml.Unmarshal([]byte(input), &cudYaml)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+
+	newNode = func(resources any) core.Node {
+		return newCudNode(resources.(map[string]any))
+	}
+
+	for _, rule := range cudYaml.EdgeRules {
+		// クロージャー内で使用するためにルールをコピー
+		currentRule := rule
+		fireCondition := createFireConditionFunc(currentRule.FireCondition)
+		blockCondition := createBlockConditionFunc(currentRule.BlockCondition)
+
+		// effect配列の処理
+		if len(currentRule.Effect) == 0 {
+			return nil, nil, nil, fmt.Errorf("effect cannot be empty for rule: %s", currentRule.Name)
+		}
+
+		edgeRule, err := core.NewEdgeRule(
+			currentRule.Name,
+			func(n *core.Node) *core.Node {
+				currentResources, ok := (*n).GetResources().(map[string]any)
+				if !ok {
+					panic(fmt.Sprintf("node resources is not map[string]any: %v", n))
+				}
+				newResources := make(map[string]any)
+				// 既存のリソースをコピー
+				for k, v := range currentResources {
+					newResources[k] = v
+				}
+
+				// 各effectを順番に適用
+				for _, effect := range currentRule.Effect {
+					if effect.Resource.Key == "" {
+						panic(fmt.Sprintf("resource key cannot be empty for rule: %s", currentRule.Name))
+					}
+
+					switch effect.Action {
+					case "create":
+						if effect.Resource.Value == nil {
+							panic(fmt.Sprintf("resource value cannot be nil for create action in rule: %s", currentRule.Name))
+						}
+						newResources[effect.Resource.Key] = effect.Resource.Value
+
+					case "update":
+						if _, exists := newResources[effect.Resource.Key]; !exists {
+							panic(fmt.Sprintf("rule: %v, key %s not found in current resources %v", currentRule, effect.Resource.Key, newResources))
+						}
+						if effect.Resource.Value == nil {
+							panic(fmt.Sprintf("resource value cannot be nil for update action in rule: %s", currentRule.Name))
+						}
+						newResources[effect.Resource.Key] = effect.Resource.Value
+
+					case "delete":
+						delete(newResources, effect.Resource.Key)
+
+					default:
+						panic(fmt.Sprintf("unknown action: %s in rule: %s", effect.Action, currentRule.Name))
+					}
+				}
+
+				newNode := newNode(newResources)
+				return &newNode
+			},
+			fireCondition,
+			blockCondition,
+		)
+		if err != nil {
+			return nil, nil, nil, err
+		}
+		edgeRules = append(edgeRules, edgeRule)
+	}
+
+	return newNode(cudYaml.StartResources), newNode, edgeRules, nil
+}

--- a/pkg/std-impl/cud/input.go
+++ b/pkg/std-impl/cud/input.go
@@ -35,7 +35,7 @@ func createFireConditionFunc(conditionExpr string) func(*core.Node) bool {
 		}
 	}
 
-	program, err := expr.Compile(conditionExpr)
+	program, err := expr.Compile(conditionExpr, expr.AllowUndefinedVariables())
 	if err != nil {
 		panic(fmt.Sprintf("failed to compile fire condition expression: %s, error: %v", conditionExpr, err))
 	}
@@ -67,7 +67,7 @@ func createBlockConditionFunc(conditionExpr string) func(*core.Node) bool {
 		}
 	}
 
-	program, err := expr.Compile(conditionExpr)
+	program, err := expr.Compile(conditionExpr, expr.AllowUndefinedVariables())
 	if err != nil {
 		panic(fmt.Sprintf("failed to compile block condition expression: %s, error: %v", conditionExpr, err))
 	}

--- a/pkg/std-impl/cud/node.go
+++ b/pkg/std-impl/cud/node.go
@@ -1,0 +1,92 @@
+package cud
+
+import (
+	"encoding/json"
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/yuukiiwai/blindspot/pkg/core"
+)
+
+// CudNode キーバリューペアのリソースの状態を表現
+type CudNode map[string]any
+
+// GetID ノードの一意な識別子を生成
+func (n CudNode) GetID() string {
+	if len(n) == 0 {
+		return "empty"
+	}
+
+	// キーでソートして一意性を保証
+	keys := make([]string, 0, len(n))
+	for k := range n {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+
+	var parts []string
+	for _, k := range keys {
+		// 値をJSON形式で文字列化して一意性を保証
+		valueBytes, err := json.Marshal(n[k])
+		if err != nil {
+			panic(fmt.Sprintf("failed to marshal value for key %s: %v", k, err))
+		}
+		parts = append(parts, fmt.Sprintf("%s:%s", k, string(valueBytes)))
+	}
+
+	return strings.Join(parts, ",")
+}
+
+// Equals ノードが同じかどうかを判定
+func (n CudNode) Equals(other core.Node) bool {
+	return n.GetID() == other.GetID()
+}
+
+// GetResources リソースのマップを取得
+func (n CudNode) GetResources() any {
+	return map[string]any(n)
+}
+
+// GetResourcesString リソースのリストを文字列で取得
+func (n CudNode) GetResourcesString() []string {
+	if len(n) == 0 {
+		return []string{"empty"}
+	}
+
+	// キーでソートして出力の一貫性を保証
+	keys := make([]string, 0, len(n))
+	for k := range n {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+
+	var result []string
+	for _, k := range keys {
+		// 値をJSON形式で表示
+		valueBytes, err := json.Marshal(n[k])
+		if err != nil {
+			result = append(result, fmt.Sprintf("%s:<marshal_error>", k))
+		} else {
+			result = append(result, fmt.Sprintf("%s:%s", k, string(valueBytes)))
+		}
+	}
+
+	return result
+}
+
+func newCudNode(resources map[string]any) CudNode {
+	// nilチェックとコピー作成
+	if resources == nil {
+		return CudNode{}
+	}
+
+	result := make(CudNode, len(resources))
+	for k, v := range resources {
+		if k != "" { // 空キーは除外
+			result[k] = v
+		}
+	}
+
+	return result
+}

--- a/pkg/std-impl/cud/node.go
+++ b/pkg/std-impl/cud/node.go
@@ -1,10 +1,10 @@
 package cud
 
 import (
+	"crypto/md5"
 	"encoding/json"
 	"fmt"
 	"sort"
-	"strings"
 
 	"github.com/yuukiiwai/blindspot/pkg/core"
 )
@@ -14,28 +14,17 @@ type CudNode map[string]any
 
 // GetID ノードの一意な識別子を生成
 func (n CudNode) GetID() string {
+	var marshaled []byte
+	var err error
 	if len(n) == 0 {
-		return "empty"
-	}
-
-	// キーでソートして一意性を保証
-	keys := make([]string, 0, len(n))
-	for k := range n {
-		keys = append(keys, k)
-	}
-	sort.Strings(keys)
-
-	var parts []string
-	for _, k := range keys {
-		// 値をJSON形式で文字列化して一意性を保証
-		valueBytes, err := json.Marshal(n[k])
+		marshaled = []byte("")
+	} else {
+		marshaled, err = json.Marshal(n)
 		if err != nil {
-			panic(fmt.Sprintf("failed to marshal value for key %s: %v", k, err))
+			panic(fmt.Sprintf("failed to marshal node: %v", err))
 		}
-		parts = append(parts, fmt.Sprintf("%s:%s", k, string(valueBytes)))
 	}
-
-	return strings.Join(parts, ",")
+	return fmt.Sprintf("%x", md5.Sum(marshaled))
 }
 
 // Equals ノードが同じかどうかを判定

--- a/pkg/std-impl/output/dot.go
+++ b/pkg/std-impl/output/dot.go
@@ -22,8 +22,20 @@ func (f *DotFormatter) Format(generator *core.Generator) (string, error) {
 	dot.WriteString("  rankdir=LR;\n")
 	dot.WriteString("  node [shape=box];\n\n")
 
-	// ノードの出力
+	// ノードの出力（開始ノードを最初に出力）
+	startNode := generator.GetStartNode()
+	if startNode != nil {
+		nodeID := getDotNodeID(startNode)
+		label := getDotNodeLabel(startNode)
+		dot.WriteString(fmt.Sprintf("  %s [label=\"%s\"];\n", nodeID, label))
+	}
+
+	// 開始ノード以外のノードを出力
 	for _, node := range generator.GetNodes() {
+		// 開始ノードは既に出力済みなのでスキップ
+		if startNode != nil && (*node).GetID() == (*startNode).GetID() {
+			continue
+		}
 		nodeID := getDotNodeID(node)
 		label := getDotNodeLabel(node)
 		dot.WriteString(fmt.Sprintf("  %s [label=\"%s\"];\n", nodeID, label))
@@ -46,7 +58,7 @@ func (f *DotFormatter) Format(generator *core.Generator) (string, error) {
 
 // getDotNodeID ノードのDOT IDを生成
 func getDotNodeID(node *core.Node) string {
-	id := (*node).GetID()
+	id := fmt.Sprintf("\"%s\"", (*node).GetID())
 
 	// 明示的にemptyの場合
 	if id == "empty" {

--- a/pkg/std-impl/output/mermaid.go
+++ b/pkg/std-impl/output/mermaid.go
@@ -20,8 +20,20 @@ func (f *MermaidFormatter) Format(generator *core.Generator) (string, error) {
 	var mermaid strings.Builder
 	mermaid.WriteString("graph TD\n")
 
-	// ノードの出力
+	// ノードの出力（開始ノードを最初に出力）
+	startNode := generator.GetStartNode()
+	if startNode != nil {
+		nodeID := getMermaidNodeID(startNode)
+		label := getMermaidNodeLabel(startNode)
+		mermaid.WriteString(fmt.Sprintf("    %s[\"%s\"]\n", nodeID, label))
+	}
+
+	// 開始ノード以外のノードを出力
 	for _, node := range generator.GetNodes() {
+		// 開始ノードは既に出力済みなのでスキップ
+		if startNode != nil && (*node).GetID() == (*startNode).GetID() {
+			continue
+		}
 		nodeID := getMermaidNodeID(node)
 		label := getMermaidNodeLabel(node)
 		mermaid.WriteString(fmt.Sprintf("    %s[\"%s\"]\n", nodeID, label))

--- a/pkg/std-impl/stringlist/stringlist_test.go
+++ b/pkg/std-impl/stringlist/stringlist_test.go
@@ -9,9 +9,9 @@ import (
 )
 
 var expectedOutput = `graph TD
+    empty["empty"]
     a["a"]
     a_b["a<br/>b"]
-    empty["empty"]
 
     empty -->|create_a| a
     a -->|create_b_from_a| a_b


### PR DESCRIPTION
# Pull Request

## 概要
コマンドライン引数の処理方法を改善し、CUDパーサーを統合しました。位置引数の導入と明示的なフォーマット指定により、より直感的で拡張性の高いCLIインターフェースを実現しました。

## 変更内容
- [x] 新機能の追加
- [x] リファクタリング
- [ ] バグ修正
- [x] ドキュメント更新
- [x] テストの追加・修正
- [ ] その他: 

## 詳細

### 1. コマンドライン引数の改善
- **位置引数の導入**: 入力ファイルを位置引数として受け取るように変更
- **フォーマット指定の改善**: ファイル拡張子ベースから明示的なフォーマット指定（`-input`フラグ）に変更
- **FlagSetの活用**: 混合引数（位置引数+フラグ）の適切な処理

**変更前:** `blindspot -input rules.json -output mermaid`
**変更後:** `blindspot rules.json -input stringlist -output mermaid`

### 2. CUDパーサーの統合
- CUDパーサーをメインコマンドに統合
- 式評価での未定義変数許可（`expr.AllowUndefinedVariables()`）
- CudNodeのID生成をMD5ハッシュベースに改善

### 3. 出力フォーマッターの改善
- 開始ノードを最初に出力するように順序を改善
- DOTフォーマットでのノードID引用符処理の修正

### 4. Generator機能の拡張
- `GetStartNode()`メソッドの追加で開始ノードへの直接アクセスを提供

## 動作確認
- [x] ローカルでのテスト実行
- [x] ビルド確認
- [x] 手動テスト実行
- [ ] その他: 

## 影響範囲
- [ ] 既存機能に影響なし
- [ ] 既存機能に影響あり（詳細: ）
- [x] 破壊的変更あり（詳細: コマンドライン引数の構文が変更されているため、既存スクリプトの更新が必要）

## 関連Issue
Closes #

## スクリーンショット
<!-- 必要に応じてスクリーンショットを添付してください -->

## チェックリスト
- [x] コードは適切にフォーマットされている(`go fmt`)
- [x] テストが追加されている（新機能・バグ修正の場合）
- [x] すべてのテストが通る(`go test ./...`)
- [x] ドキュメントが更新されている（必要に応じて）
- [x] READMEが更新されている（必要に応じて）